### PR TITLE
Add address widget

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,6 +7,7 @@
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
     "features": {
+        "ghcr.io/devcontainers/features/git:1": {}
     },
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,9 +6,15 @@
 	"image": "mcr.microsoft.com/devcontainers/javascript-node:1-22-bookworm",
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
+    // @see: https://marcandreuf.com/blog/2024-07-12-gitdevcont/
     "features": {
         "ghcr.io/devcontainers/features/git:1": {}
     },
+
+    "mounts": [
+        "source=${localEnv:HOME}/.gitconfig,target=/home/vscode/.gitconfig,type=bind,consistency=cached",
+        "source=${localEnv:HOME}/.ssh/id_rsa,target=/home/vscode/.ssh/id_rsa,type=bind,consistency=cached"
+    ]
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,51 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/typescript-node
+{
+	"name": "Node.js & TypeScript",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/javascript-node:1-22-bookworm",
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+    "features": {
+    },
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+	"forwardPorts": [3333],
+
+    // Use 'portsAttributes' to set default properties for specific forwarded ports. 
+	// More info: https://containers.dev/implementors/json_reference/#port-attributes
+//	"portsAttributes": {
+//		"3000": {
+//			"label": "Hello Remote World",
+//			"onAutoForward": "notify"
+//..		}
+//	},
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+    "postCreateCommand": {
+        "Configure Build Tools": "sudo corepack enable npm; sudo npm install -g hereby; npm ci; npm start"
+    },
+
+	// Configure tool-specific properties.
+    "customizations": {
+        "vscode": {
+            "settings": {
+                "terminal.integrated.defaultProfile.linux": "bash",
+                "terminal.integrated.profiles.linux": {
+                    "bash": {
+                        "path": "/bin/bash",
+                        "icon": "terminal-bash"
+                    }
+                }
+            },
+            "extensions": [
+                "dbaeumer.vscode-eslint",
+                "dprint.dprint"
+            ]
+        }
+    },
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+    "remoteUser": "node"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ $RECYCLE.BIN/
 Thumbs.db
 UserInterfaceState.xcuserstate
 .env
+
+.gitconfig

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@district09/lod-widgets",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@district09/lod-widgets",
-      "version": "1.3.3",
-      "license": "MIT",
+      "version": "1.3.4",
+      "license": "EUPL",
       "devDependencies": {
         "@digipolis-gent/opening-hours-widget": "^0.2.0",
         "@stencil/core": "^4.29.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@district09/lod-widgets",
-  "version": "1.3.4",
+  "version": "1.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@district09/lod-widgets",
-      "version": "1.3.4",
+      "version": "1.3.7",
       "license": "EUPL",
       "dependencies": {
         "@digipolis-gent/modal": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
       "import": "./dist/lod-widgets/lod-widgets.esm.js",
       "require": "./dist/lod-widgets/lod-widgets.cjs.js"
     },
+    "./lod-address": {
+      "import": "./dist/components/lod-address.js",
+      "types": "./dist/components/lod-address.ts"
+    },
     "./lod-cards": {
       "import": "./dist/components/lod-cards.js",
       "types": "./dist/components/lod-cards.ts"
@@ -75,5 +79,6 @@
     "puppeteer": "^24.6.1",
     "@digipolis-gent/opening-hours-widget": "^0.2.0"
   },
-  "license": "EUPL"
+  "license": "EUPL",
+  "packageManager": "npm@11.3.0+sha512.96eb611483f49c55f7fa74df61b588de9e213f80a256728e6798ddc67176c7b07e4a1cfc7de8922422cbce02543714367037536955221fa451b0c4fefaf20c66"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@district09/lod-widgets",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",
@@ -80,7 +80,6 @@
     "puppeteer": "^24.6.1"
   },
   "license": "EUPL",
-  "packageManager": "npm@11.3.0+sha512.96eb611483f49c55f7fa74df61b588de9e213f80a256728e6798ddc67176c7b07e4a1cfc7de8922422cbce02543714367037536955221fa451b0c4fefaf20c66"
   "dependencies": {
     "@digipolis-gent/modal": "^1.0.4",
     "@opendatasoft/api-client": "^21.7.0",

--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,9 @@ Need help? Check out the docs [here](https://stenciljs.com/docs/my-first-compone
 
 ## Available components
 
+- LodAddress
+  - HTML: <lod-address/>
+  - [Documentation](https://github.com/StadGent/js_widget-lod/blob/main/src/components/lod-address/readme.md)
 - LodTable
   - HTML: <lod-table/>
   - [Documentation](https://github.com/StadGent/js_widget-lod/blob/main/src/components/lod-table/readme.md)

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -173,8 +173,6 @@ export namespace Components {
          */
         "taxonomy": string;
     }
-    interface LodMap {
-    }
     interface LodOpeningHours {
         "channelId": string | boolean;
         "endpoint": string;
@@ -300,12 +298,6 @@ declare global {
         prototype: HTMLLodDecisionsListElement;
         new (): HTMLLodDecisionsListElement;
     };
-    interface HTMLLodMapElement extends Components.LodMap, HTMLStencilElement {
-    }
-    var HTMLLodMapElement: {
-        prototype: HTMLLodMapElement;
-        new (): HTMLLodMapElement;
-    };
     interface HTMLLodOpeningHoursElement extends Components.LodOpeningHours, HTMLStencilElement {
     }
     var HTMLLodOpeningHoursElement: {
@@ -330,7 +322,6 @@ declare global {
         "lod-cards": HTMLLodCardsElement;
         "lod-decision-card": HTMLLodDecisionCardElement;
         "lod-decisions-list": HTMLLodDecisionsListElement;
-        "lod-map": HTMLLodMapElement;
         "lod-opening-hours": HTMLLodOpeningHoursElement;
         "lod-regulations-list": HTMLLodRegulationsListElement;
         "lod-table": HTMLLodTableElement;
@@ -504,8 +495,6 @@ declare namespace LocalJSX {
          */
         "taxonomy"?: string;
     }
-    interface LodMap {
-    }
     interface LodOpeningHours {
         "channelId"?: string | boolean;
         "endpoint"?: string;
@@ -605,7 +594,6 @@ declare namespace LocalJSX {
         "lod-cards": LodCards;
         "lod-decision-card": LodDecisionCard;
         "lod-decisions-list": LodDecisionsList;
-        "lod-map": LodMap;
         "lod-opening-hours": LodOpeningHours;
         "lod-regulations-list": LodRegulationsList;
         "lod-table": LodTable;
@@ -620,7 +608,6 @@ declare module "@stencil/core" {
             "lod-cards": LocalJSX.LodCards & JSXBase.HTMLAttributes<HTMLLodCardsElement>;
             "lod-decision-card": LocalJSX.LodDecisionCard & JSXBase.HTMLAttributes<HTMLLodDecisionCardElement>;
             "lod-decisions-list": LocalJSX.LodDecisionsList & JSXBase.HTMLAttributes<HTMLLodDecisionsListElement>;
-            "lod-map": LocalJSX.LodMap & JSXBase.HTMLAttributes<HTMLLodMapElement>;
             "lod-opening-hours": LocalJSX.LodOpeningHours & JSXBase.HTMLAttributes<HTMLLodOpeningHoursElement>;
             "lod-regulations-list": LocalJSX.LodRegulationsList & JSXBase.HTMLAttributes<HTMLLodRegulationsListElement>;
             "lod-table": LocalJSX.LodTable & JSXBase.HTMLAttributes<HTMLLodTableElement>;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -6,6 +6,24 @@
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 export namespace Components {
+    interface LodAddress {
+        /**
+          * Show a link to JSON-LD for SEO.
+         */
+        "includeLd": boolean;
+        /**
+          * Show a map or a link to a map.
+         */
+        "mode": 'link' | 'map' | 'none';
+        /**
+          * The name of the address.
+         */
+        "name": string;
+        /**
+          * The unique uri of the address.
+         */
+        "uri": string;
+    }
     interface LodCard {
         /**
           * The location address of the event
@@ -155,6 +173,8 @@ export namespace Components {
          */
         "taxonomy": string;
     }
+    interface LodMap {
+    }
     interface LodOpeningHours {
         "channelId": string | boolean;
         "endpoint": string;
@@ -250,6 +270,12 @@ export namespace Components {
     }
 }
 declare global {
+    interface HTMLLodAddressElement extends Components.LodAddress, HTMLStencilElement {
+    }
+    var HTMLLodAddressElement: {
+        prototype: HTMLLodAddressElement;
+        new (): HTMLLodAddressElement;
+    };
     interface HTMLLodCardElement extends Components.LodCard, HTMLStencilElement {
     }
     var HTMLLodCardElement: {
@@ -274,6 +300,12 @@ declare global {
         prototype: HTMLLodDecisionsListElement;
         new (): HTMLLodDecisionsListElement;
     };
+    interface HTMLLodMapElement extends Components.LodMap, HTMLStencilElement {
+    }
+    var HTMLLodMapElement: {
+        prototype: HTMLLodMapElement;
+        new (): HTMLLodMapElement;
+    };
     interface HTMLLodOpeningHoursElement extends Components.LodOpeningHours, HTMLStencilElement {
     }
     var HTMLLodOpeningHoursElement: {
@@ -293,16 +325,36 @@ declare global {
         new (): HTMLLodTableElement;
     };
     interface HTMLElementTagNameMap {
+        "lod-address": HTMLLodAddressElement;
         "lod-card": HTMLLodCardElement;
         "lod-cards": HTMLLodCardsElement;
         "lod-decision-card": HTMLLodDecisionCardElement;
         "lod-decisions-list": HTMLLodDecisionsListElement;
+        "lod-map": HTMLLodMapElement;
         "lod-opening-hours": HTMLLodOpeningHoursElement;
         "lod-regulations-list": HTMLLodRegulationsListElement;
         "lod-table": HTMLLodTableElement;
     }
 }
 declare namespace LocalJSX {
+    interface LodAddress {
+        /**
+          * Show a link to JSON-LD for SEO.
+         */
+        "includeLd"?: boolean;
+        /**
+          * Show a map or a link to a map.
+         */
+        "mode"?: 'link' | 'map' | 'none';
+        /**
+          * The name of the address.
+         */
+        "name"?: string;
+        /**
+          * The unique uri of the address.
+         */
+        "uri"?: string;
+    }
     interface LodCard {
         /**
           * The location address of the event
@@ -452,6 +504,8 @@ declare namespace LocalJSX {
          */
         "taxonomy"?: string;
     }
+    interface LodMap {
+    }
     interface LodOpeningHours {
         "channelId"?: string | boolean;
         "endpoint"?: string;
@@ -546,10 +600,12 @@ declare namespace LocalJSX {
         "tableCaption"?: string;
     }
     interface IntrinsicElements {
+        "lod-address": LodAddress;
         "lod-card": LodCard;
         "lod-cards": LodCards;
         "lod-decision-card": LodDecisionCard;
         "lod-decisions-list": LodDecisionsList;
+        "lod-map": LodMap;
         "lod-opening-hours": LodOpeningHours;
         "lod-regulations-list": LodRegulationsList;
         "lod-table": LodTable;
@@ -559,10 +615,12 @@ export { LocalJSX as JSX };
 declare module "@stencil/core" {
     export namespace JSX {
         interface IntrinsicElements {
+            "lod-address": LocalJSX.LodAddress & JSXBase.HTMLAttributes<HTMLLodAddressElement>;
             "lod-card": LocalJSX.LodCard & JSXBase.HTMLAttributes<HTMLLodCardElement>;
             "lod-cards": LocalJSX.LodCards & JSXBase.HTMLAttributes<HTMLLodCardsElement>;
             "lod-decision-card": LocalJSX.LodDecisionCard & JSXBase.HTMLAttributes<HTMLLodDecisionCardElement>;
             "lod-decisions-list": LocalJSX.LodDecisionsList & JSXBase.HTMLAttributes<HTMLLodDecisionsListElement>;
+            "lod-map": LocalJSX.LodMap & JSXBase.HTMLAttributes<HTMLLodMapElement>;
             "lod-opening-hours": LocalJSX.LodOpeningHours & JSXBase.HTMLAttributes<HTMLLodOpeningHoursElement>;
             "lod-regulations-list": LocalJSX.LodRegulationsList & JSXBase.HTMLAttributes<HTMLLodRegulationsListElement>;
             "lod-table": LocalJSX.LodTable & JSXBase.HTMLAttributes<HTMLLodTableElement>;

--- a/src/components/lod-address/lod-address.scss
+++ b/src/components/lod-address/lod-address.scss
@@ -1,0 +1,20 @@
+.lod-address {
+
+  :host {
+    display: block;
+  }
+  
+  .address-card {
+    padding: 0.5rem;
+  }
+  
+  .line {
+    margin: 0;
+  }
+  
+  .map-link {
+    color: #c00;
+    text-decoration: underline;
+    font-weight: 500;
+  }
+}

--- a/src/components/lod-address/lod-address.tsx
+++ b/src/components/lod-address/lod-address.tsx
@@ -1,0 +1,123 @@
+import { Component, Prop, State, h, Watch, Element } from '@stencil/core';
+
+@Component({
+  tag: "lod-address",
+  styleUrl: "lod-address.scss",
+  shadow: false,
+})
+export class LodAddress {
+
+  /**
+   * The unique uri of the address.
+   */
+  @Prop() uri: string;
+
+  /**
+   * The name of the address.
+   */
+  @Prop() name: string;
+
+  /**
+   * Show a map or a link to a map.
+   */
+  @Prop() mode: 'link' | 'map' | 'none' = 'none';
+
+  /**
+   * Show a link to JSON-LD for SEO.
+   */
+  @Prop() includeLd: boolean = false;
+
+  @State() data: any;
+
+  @Element() el: HTMLElement;
+
+  componentWillLoad() {
+    if (this.uri) {
+      this.fetchAddress(this.uri);
+    }
+  }
+
+  componentDidLoad() {
+    if (this.includeLd && this.data && this.uri) {
+      const id = `ld-json-${btoa(this.uri).replace(/[^a-z0-9]/gi, '')}`;
+      console.log('ld-json', id);
+      if (!document.getElementById(id)) {
+        const script = document.createElement('script');
+        script.type = 'application/ld+json';
+        script.id = id;
+        script.textContent = JSON.stringify(this.data);
+        document.head.appendChild(script);
+      }
+    }
+  }
+
+  @Watch('uri')
+  async fetchAddress(newUri: string) {
+    try {
+      const response = await fetch(newUri, {
+        headers: { Accept: 'application/ld+json' },
+      });
+      const json = await response.json();
+      this.data = json;
+    } catch (err) {
+      console.error('Error fetching address:', err);
+    }
+  }
+
+  // Getters voor afgeleide weergave
+  get street(): string {
+    const s = this.data?.straatnaam?.straatnaam?.geografischeNaam?.spelling;
+    const nr = this.data?.huisnummer;
+    return s && nr ? `${s} ${nr}` : s || '';
+  }
+
+  get city(): string {
+    return this.data?.gemeente?.gemeentenaam?.geografischeNaam?.spelling || '';
+  }
+
+  get postcode(): string {
+    return this.data?.postinfo?.objectId || '';
+  }
+
+  get fullAddress(): string {
+    //return `${this.street}, ${this.postcode} ${this.city}`.trim();
+    return this.data?.volledigAdres?.geografischeNaam?.spelling || '';
+  }
+
+  get googleMapsLink(): string {
+    return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(this.fullAddress)}`;
+  }
+
+  render() {
+    if (!this.data) {
+      return <p>Adres wordt geladen...</p>;
+    }
+
+    return (
+      <div class="address-card">
+        <i class="icon-marker" aria-hidden="true"></i>
+        <span>
+          <strong>{this.name}</strong>
+            —
+          {this.fullAddress}
+        </span>
+
+
+        {this.mode === 'link' && (
+          <a class="map-link" href={this.googleMapsLink} target="_blank" rel="noopener noreferrer">
+            Bekijk op kaart <span aria-hidden="true"></span>
+          </a>
+        )}
+
+        {this.mode === 'map' && (
+          <iframe
+            class="map-iframe"
+            loading="lazy"
+            referrerPolicy="no-referrer-when-downgrade"
+            src={`https://www.google.com/maps?q=${encodeURIComponent(this.fullAddress)}&output=embed`}
+          ></iframe>
+        )}
+      </div>
+    );
+  }
+}

--- a/src/components/lod-address/readme.md
+++ b/src/components/lod-address/readme.md
@@ -1,0 +1,20 @@
+# lod-address
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property    | Attribute    | Description                     | Type                        | Default     |
+| ----------- | ------------ | ------------------------------- | --------------------------- | ----------- |
+| `includeLd` | `include-ld` | Show a link to JSON-LD for SEO. | `boolean`                   | `false`     |
+| `mode`      | `mode`       | Show a link to a map.           | `"link" \| "map" \| "none"` | `'none'`    |
+| `name`      | `name`       | The name of the address         | `string`                    | `undefined` |
+| `uri`       | `uri`        | The id of the address           | `string`                    | `undefined` |
+
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/lod-address/readme.md
+++ b/src/components/lod-address/readme.md
@@ -10,9 +10,9 @@
 | Property    | Attribute    | Description                     | Type                        | Default     |
 | ----------- | ------------ | ------------------------------- | --------------------------- | ----------- |
 | `includeLd` | `include-ld` | Show a link to JSON-LD for SEO. | `boolean`                   | `false`     |
-| `mode`      | `mode`       | Show a link to a map.           | `"link" \| "map" \| "none"` | `'none'`    |
-| `name`      | `name`       | The name of the address         | `string`                    | `undefined` |
-| `uri`       | `uri`        | The id of the address           | `string`                    | `undefined` |
+| `mode`      | `mode`       | Show a map or a link to a map.  | `"link" \| "map" \| "none"` | `'none'`    |
+| `name`      | `name`       | The name of the address.        | `string`                    | `undefined` |
+| `uri`       | `uri`        | The unique uri of the address.  | `string`                    | `undefined` |
 
 
 ----------------------------------------------

--- a/src/index.html
+++ b/src/index.html
@@ -31,6 +31,18 @@
     <script nomodule src="build/lod-widgets.js"></script>
   </head>
   <body class="cs--blue">
+    <lod-address
+      name="Stad Gent"
+      uri="https://data.vlaanderen.be/id/adres/1475186"
+      mode="map"
+      include-ld="true"
+    ></lod-address>
+    <lod-address
+      name="OCMW Gent"
+      uri="https://data.vlaanderen.be/id/adres/2947785"
+      mode="link"
+      include-ld="true"
+    ></lod-address>
     <lod-opening-hours
       service-id="10672"
       show-all-hours="true"


### PR DESCRIPTION
Example usage:
```
<lod-address
  name="Stad Gent"
  uri="https://data.vlaanderen.be/id/adres/1475186"
  mode="map"
  include-ld="true"
></lod-address>
<lod-address
  name="OCMW Gent"
  uri="https://data.vlaanderen.be/id/adres/2947785"
  mode="link"
  include-ld="true"
></lod-address>
```